### PR TITLE
Applying the amendment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ $hp2p.go.peer -j -id peer2 -t title
 $hp2p.go.peer -id peer3
 ```
 
+## Live Demo
+You can check the running test server by accessing the following URL:  
+http://144.24.179.237:8081/
+  
+And by setting the following information in clientconfig.json, you can connect to the running server/peer and test it.
+```
+...
+"OVERLAY_SERVER_ADDR" : "http://144.24.179.237:8081",
+"SIGNALING_SERVER_ADDR" : "ws://144.24.179.237:8082",
+...
+```
+  
+Use the following command to connect to the running peer.  
+(xxx is an arbitrary peer ID, excluding peer1, peer2, peer3, and peer4.)
+```
+$hp2p.go.peer -j -id [xxx] -t test_overlay
+```
+Alternatively, you can also create a new overlay to test with the following command.
+```
+$hp2p.go.peer -c -id [xxx] -t [overlay_name]
+```
+  
 ## LICENSE
 
 The MIT License

--- a/apiHandler.go
+++ b/apiHandler.go
@@ -313,7 +313,7 @@ func (handler *ApiHandler) overlayList(p graphql.ResolveParams) (interface{}, er
 		ov.Type = rslt.Overlay.Type
 		ov.SubType = rslt.Overlay.SubType
 		ov.OwnerId = rslt.Overlay.OwnerId
-		ov.Expires = rslt.Overlay.Expires
+		//ov.Expires = rslt.Overlay.Expires
 		ov.Description = rslt.Overlay.Description
 		ov.Auth = rslt.Overlay.Auth
 
@@ -340,7 +340,7 @@ func (handler *ApiHandler) overlayStatus(p graphql.ResolveParams) (interface{}, 
 	rslt.Type = (*handler.connectObj).OverlayInfo().Type
 	rslt.SubType = (*handler.connectObj).OverlayInfo().SubType
 	rslt.OwnerId = (*handler.connectObj).OverlayInfo().OwnerId
-	rslt.Expires = (*handler.connectObj).GetPeerConfig().Expires
+	//rslt.Expires = (*handler.connectObj).GetPeerConfig().Expires
 	rslt.Description = &(*handler.connectObj).OverlayInfo().Description
 	rslt.Auth = (*handler.connectObj).OverlayInfo().Auth
 	rslt.TicketId = (*handler.connectObj).PeerInfo().TicketId
@@ -420,7 +420,7 @@ func (handler *ApiHandler) overlayCreate(p graphql.ResolveParams) (interface{}, 
 	hoc.Overlay.Type = strings.Split(ovtype, "/")[0]
 	hoc.Overlay.SubType = strings.Split(ovtype, "/")[1]
 	hoc.Overlay.OwnerId = (*handler.connectObj).PeerId()
-	hoc.Overlay.Expires = expires
+	//hoc.Overlay.Expires = expires
 	hoc.Overlay.Description = description
 	hoc.Overlay.HeartbeatInterval = heartbeatInterval
 	hoc.Overlay.HeartbeatTimeout = heartbeatTimeout
@@ -501,12 +501,12 @@ func (handler *ApiHandler) overlayJoin(p graphql.ResolveParams) (interface{}, er
 func (handler *ApiHandler) overlayModify(p graphql.ResolveParams) (interface{}, error) {
 	ovid, _ := p.Args["overlayId"].(string)
 	title, _ := p.Args["title"].(string)
-	expires, _ := p.Args["expires"].(int)
+	//expires, _ := p.Args["expires"].(int)
 	desc, _ := p.Args["description"].(string)
 	adminKey, _ := p.Args["adminKey"].(string)
 	accessKey, _ := p.Args["accessKey"].(string)
 
-	logger.Println(logger.INFO, "api overlay modify ovid:", ovid, "title:", title, "expires:", expires)
+	//logger.Println(logger.INFO, "api overlay modify ovid:", ovid, "title:", title, "expires:", expires)
 	logger.Println(logger.INFO, "api overlay modify desc:", desc, "adminKey:", adminKey, "accessKey:", accessKey)
 
 	hom := connect.HybridOverlayModification{}
@@ -515,9 +515,9 @@ func (handler *ApiHandler) overlayModify(p graphql.ResolveParams) (interface{}, 
 		hom.Overlay.Title = &title
 	}
 	hom.Overlay.OwnerId = (*handler.connectObj).PeerId()
-	if expires > 0 {
+	/*if expires > 0 {
 		hom.Overlay.Expires = &expires
-	}
+	}*/
 	if len(desc) > 0 {
 		hom.Overlay.Description = &desc
 	}

--- a/apiHandler.go
+++ b/apiHandler.go
@@ -1,18 +1,18 @@
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2022 ETRI
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 
 package main
 
@@ -329,7 +329,7 @@ func (handler *ApiHandler) overlayList(p graphql.ResolveParams) (interface{}, er
 func (handler *ApiHandler) overlayStatus(p graphql.ResolveParams) (interface{}, error) {
 	logger.Println(logger.INFO, "api overlay status")
 
-	if (*handler.connectObj).OverlayInfo().TicketId == nil {
+	if (*handler.connectObj).PeerInfo().TicketId < 0 {
 		return nil, nil
 	}
 
@@ -340,10 +340,10 @@ func (handler *ApiHandler) overlayStatus(p graphql.ResolveParams) (interface{}, 
 	rslt.Type = (*handler.connectObj).OverlayInfo().Type
 	rslt.SubType = (*handler.connectObj).OverlayInfo().SubType
 	rslt.OwnerId = (*handler.connectObj).OverlayInfo().OwnerId
-	rslt.Expires = (*handler.connectObj).OverlayInfo().Expires
+	rslt.Expires = (*handler.connectObj).GetPeerConfig().Expires
 	rslt.Description = &(*handler.connectObj).OverlayInfo().Description
 	rslt.Auth = (*handler.connectObj).OverlayInfo().Auth
-	rslt.TicketId = *(*handler.connectObj).OverlayInfo().TicketId
+	rslt.TicketId = (*handler.connectObj).PeerInfo().TicketId
 	rslt.HeartbeatInterval = (*handler.connectObj).OverlayInfo().HeartbeatInterval
 	rslt.HeartbeatTimeout = (*handler.connectObj).OverlayInfo().HeartbeatTimeout
 
@@ -477,23 +477,23 @@ func (handler *ApiHandler) overlayJoin(p graphql.ResolveParams) (interface{}, er
 	hoj.Overlay.OverlayId = ovid
 	hoj.Overlay.Type = (*handler.connectObj).OverlayInfo().Type
 	hoj.Overlay.SubType = (*handler.connectObj).OverlayInfo().SubType
-	hoj.Overlay.Expires = expires
 	hoj.Overlay.Auth = &(*handler.connectObj).OverlayInfo().Auth
 	if len(accessKey) > 0 {
 		hoj.Overlay.Auth.AccessKey = &accessKey
 	}
-	hoj.Overlay.Recovery = &recovery
-	hoj.Overlay.TicketId = (*handler.connectObj).OverlayInfo().TicketId
+
 	hoj.Peer.PeerId = (*handler.connectObj).PeerId()
 	hoj.Peer.Address = (*handler.connectObj).GetPeerInfo().Address
 	if len(peerAuth) > 0 {
 		(*handler.connectObj).GetPeerInfo().Auth.Password = peerAuth
 	}
 	hoj.Peer.Auth = (*handler.connectObj).GetPeerInfo().Auth
+	hoj.Peer.Expires = &expires
+	hoj.Peer.TicketId = &(*handler.connectObj).PeerInfo().TicketId
 
 	logger.PrintJson(logger.INFO, "join option:", hoj)
 
-	joinOverlay := (*handler.connectObj).OverlayJoinBy(hoj)
+	joinOverlay := (*handler.connectObj).OverlayJoinBy(hoj, recovery)
 
 	return joinOverlay, nil
 }
@@ -569,7 +569,7 @@ func (handler *ApiHandler) overlayRefresh(p graphql.ResolveParams) (interface{},
 	hor := connect.HybridOverlayRefresh{}
 	hor.Overlay.OverlayId = ovid
 	if expires > 0 {
-		hor.Overlay.Expires = &expires
+		hor.Peer.Expires = &expires
 	}
 	if len(accessKey) > 0 {
 		hor.Overlay.Auth.AccessKey = &accessKey
@@ -589,7 +589,7 @@ func (handler *ApiHandler) overlayRefresh(p graphql.ResolveParams) (interface{},
 
 	rslt := connect.ApiOverlayRefreshResponse{}
 	rslt.OverlayId = refresh.Overlay.OverlayId
-	rslt.Expires = *refresh.Overlay.Expires
+	rslt.Expires = refresh.Peer.Expires
 	rslt.PeerId = refresh.Peer.PeerId
 
 	return rslt, nil
@@ -775,10 +775,10 @@ func (handler *ApiHandler) configQuery() *graphql.Object {
 						info.NetworkAddress = (*handler.connectObj).GetPeerInfo().Address
 						info.OverlayNetwork.OverlayTitle = (*handler.connectObj).OverlayInfo().Title
 						info.OverlayNetwork.OverlayId = (*handler.connectObj).OverlayInfo().OverlayId
-						if (*handler.connectObj).OverlayInfo().TicketId == nil {
+						if (*handler.connectObj).PeerInfo().TicketId < 0 {
 							info.OverlayNetwork.TicketId = 0
 						} else {
-							info.OverlayNetwork.TicketId = *(*handler.connectObj).OverlayInfo().TicketId
+							info.OverlayNetwork.TicketId = (*handler.connectObj).PeerInfo().TicketId
 						}
 						info.DebugLevel = logger.LEVEL
 						info.PeerAuth = (*handler.connectObj).GetPeerInfo().Auth.Password

--- a/connect/homp.go
+++ b/connect/homp.go
@@ -1,18 +1,18 @@
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2022 ETRI
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 
 package connect
 
@@ -103,14 +103,20 @@ func (self *HOMP) QueryOverlay(ovid *string, title *string, desc *string) *[]Hyb
 	return ovinfo
 }
 
-func (self *HOMP) OverlayJoin(hoj *HybridOverlayJoin) *HybridOverlayJoinResponseOverlay {
+func (self *HOMP) OverlayJoin(hoj *HybridOverlayJoin, recovery bool) *HybridOverlayJoinResponse {
 
 	logger.PrintJson(logger.WORK, "Join overlay", hoj)
+
+	url := "/peer"
+
+	if recovery {
+		url += "?recovery=true"
+	}
 
 	client := resty.New()
 	resp, err := client.R().
 		SetBody(hoj).
-		Post(self.OverlayAddr + "/peer")
+		Post(self.OverlayAddr + url)
 
 	if err != nil {
 		logger.Println(logger.WORK, "Join overlay error : ", err)
@@ -122,7 +128,7 @@ func (self *HOMP) OverlayJoin(hoj *HybridOverlayJoin) *HybridOverlayJoinResponse
 
 	logger.PrintJson(logger.WORK, "Join overlay resp", ovinfo)
 
-	return &ovinfo.Overlay
+	return ovinfo
 }
 
 func (self *HOMP) OverlayModification(hom *HybridOverlayModification) *HybridOverlayModificationOverlay {

--- a/connect/struct.go
+++ b/connect/struct.go
@@ -1,18 +1,18 @@
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2022 ETRI
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,8 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
-
+//
 
 package connect
 
@@ -86,17 +85,16 @@ type CrPolicy struct {
 }
 
 type HybridOverlayCreationOverlay struct {
-	Title             string       `json:"title"`
-	Type              string       `json:"type"`
-	SubType           string       `json:"sub-type"`
-	OwnerId           string       `json:"owner-id"`
-	Expires           int          `json:"expires"`
-	Description       string       `json:"description"`
-	HeartbeatInterval int          `json:"heartbeat-interval"`
-	HeartbeatTimeout  int          `json:"heartbeat-timeout"`
-	Auth              OverlayAuth  `json:"auth"`
-	CrPolicy          *CrPolicy    `json:"cr-policy,omitempty"`
-	TransPolicy       *TransPolicy `json:"trans_policy,omitempty"`
+	Title             string      `json:"title"`
+	Type              string      `json:"type"`
+	SubType           string      `json:"sub-type"`
+	OwnerId           string      `json:"owner-id"`
+	Expires           int         `json:"expires"`
+	Description       string      `json:"description,omitempty"`
+	HeartbeatInterval int         `json:"heartbeat-interval"`
+	HeartbeatTimeout  int         `json:"heartbeat-timeout"`
+	Auth              OverlayAuth `json:"auth"`
+	CrPolicy          *CrPolicy   `json:"cr-policy,omitempty"`
 }
 
 type HybridOverlayCreation struct {
@@ -117,23 +115,22 @@ type HybridOverlayCreationResponseOverlayInfo struct {
 	HeartbeatTimeout  int          `json:"heartbeat-timeout"`
 	Auth              *OverlayAuth `json:"auth,omitempty"`
 	CrPolicy          *CrPolicy    `json:"cr-policy,omitempty"`
-	TransPolicy       *TransPolicy `json:"trans_policy,omitempty"`
 }
 
 type HybridOverlayJoinOverlay struct {
 	OverlayId string       `json:"overlay-id"`
 	Type      string       `json:"type"`
 	SubType   string       `json:"sub-type"`
-	Expires   int          `json:"expires"`
 	Auth      *OverlayAuth `json:"auth,omitempty"`
-	Recovery  *bool        `json:"recovery,omitempty"`
-	TicketId  *int         `json:"ticket-id,omitempty"`
 }
 
 type HybridOverlayJoinPeer struct {
-	PeerId  string   `json:"peer-id"`
-	Address string   `json:"address"`
-	Auth    PeerAuth `json:"auth"`
+	PeerId     string   `json:"peer-id"`
+	InstanceId int64    `json:"instance-id"`
+	Address    string   `json:"address"`
+	Auth       PeerAuth `json:"auth"`
+	Expires    *int     `json:"expires,omitempty"`
+	TicketId   *int     `json:"ticket-id,omitempty"`
 }
 
 type HybridOverlayJoin struct {
@@ -142,34 +139,44 @@ type HybridOverlayJoin struct {
 }
 
 type HybridOverlayJoinResponseOverlay struct {
-	OverlayId         string         `json:"overlay-id"`
-	Type              string         `json:"type"`
-	SubType           string         `json:"sub-type"`
-	Expires           int            `json:"expires"`
-	HeartbeatInterval int            `json:"heartbeat-interval"`
-	HeartbeatTimeout  int            `json:"heartbeat-timeout"`
-	TicketId          int            `json:"ticket-id"`
-	Status            *OverlayStatus `json:"status,omitempty"`
-	CrPolicy          *CrPolicy      `json:"cr-policy,omitempty"`
-	TransPolicy       *TransPolicy   `json:"trans_policy,omitempty"`
+	OverlayId         string        `json:"overlay-id"`
+	Type              string        `json:"type"`
+	SubType           string        `json:"sub-type"`
+	HeartbeatInterval int           `json:"heartbeat-interval"`
+	HeartbeatTimeout  int           `json:"heartbeat-timeout"`
+	Status            OverlayStatus `json:"status"`
+	CrPolicy          *CrPolicy     `json:"cr-policy,omitempty"`
+}
+
+type HybridOverlayJoinResponsePeer struct {
+	PeerId     string `json:"peer-id"`
+	InstanceId int64  `json:"instance-id"`
+	TicketId   int    `json:"ticket-id"`
+	Expires    int    `json:"expires"`
 }
 
 type HybridOverlayJoinResponse struct {
 	Overlay HybridOverlayJoinResponseOverlay `json:"overlay"`
+	Peer    HybridOverlayJoinResponsePeer    `json:"peer"`
 }
 
 type HybridOverlayModificationOverlay struct {
-	OverlayId   string       `json:"overlay-id"`
-	Title       *string      `json:"title,omitempty"`
-	OwnerId     string       `json:"owner-id"`
-	Expires     *int         `json:"expires,omitempty"`
-	Description *string      `json:"description,omitempty"`
-	Auth        OverlayAuth  `json:"auth"`
-	TransPolicy *TransPolicy `json:"trans_policy,omitempty"`
+	OverlayId   string      `json:"overlay-id"`
+	Title       *string     `json:"title,omitempty"`
+	OwnerId     string      `json:"owner-id"`
+	Expires     *int        `json:"expires,omitempty"`
+	Description *string     `json:"description,omitempty"`
+	Auth        OverlayAuth `json:"auth"`
+}
+
+type HybridOverlayModificationOwnership struct {
+	OwnerId  *string `json:"owner-id,omitempty"`
+	AdminKey *string `json:"admin-key,omitempty"`
 }
 
 type HybridOverlayModification struct {
-	Overlay HybridOverlayModificationOverlay `json:"overlay"`
+	Overlay   HybridOverlayModificationOverlay    `json:"overlay"`
+	Ownership *HybridOverlayModificationOwnership `json:"ownership,omitempty"`
 }
 
 type HybridOverlayRemovalOverlay struct {
@@ -191,20 +198,19 @@ type HybridOverlayRemovalResponse struct {
 }
 
 type OverlayInfo struct {
-	OverlayId         string        `json:"overlay-id"`
-	Title             string        `json:"title"`
-	Type              string        `json:"type"`
-	SubType           string        `json:"sub-type"`
-	OwnerId           string        `json:"owner-id"`
-	Expires           int           `json:"expires"`
-	Description       string        `json:"description"`
-	HeartbeatInterval int           `json:"heartbeat-interval"`
-	HeartbeatTimeout  int           `json:"heartbeat-timeout"`
-	Auth              OverlayAuth   `json:"auth"`
-	CrPolicy          *CrPolicy     `json:"cr-policy"`
-	TransPolicy       *TransPolicy  `json:"trans_policy"`
-	TicketId          *int          `json:"ticket-id"`
-	Status            OverlayStatus `json:"status"`
+	OverlayId string `json:"overlay-id"`
+	Title     string `json:"title"`
+	Type      string `json:"type"`
+	SubType   string `json:"sub-type"`
+	OwnerId   string `json:"owner-id"`
+	//Expires           int         `json:"expires"`
+	Description       string      `json:"description"`
+	HeartbeatInterval int         `json:"heartbeat-interval"`
+	HeartbeatTimeout  int         `json:"heartbeat-timeout"`
+	Auth              OverlayAuth `json:"auth"`
+	CrPolicy          *CrPolicy   `json:"cr-policy"`
+	//TicketId          int           `json:"ticket-id"`
+	Status OverlayStatus `json:"status"`
 }
 
 func (self *OverlayInfo) copy(v interface{}) {
@@ -220,13 +226,12 @@ func (self *OverlayInfo) copy(v interface{}) {
 		self.Type = val.Type
 		self.SubType = val.SubType
 		self.OwnerId = val.OwnerId
-		self.Expires = val.Expires
+		//self.Expires = val.Expires
 		self.Description = val.Description
 		self.HeartbeatInterval = val.HeartbeatInterval
 		self.HeartbeatTimeout = val.HeartbeatTimeout
 		self.Auth = val.Auth
 		self.CrPolicy = val.CrPolicy
-		self.TransPolicy = val.TransPolicy
 	case *HybridOverlayCreationResponseOverlayInfo:
 		val := v.(*HybridOverlayCreationResponseOverlayInfo)
 
@@ -246,8 +251,7 @@ func (self *OverlayInfo) copy(v interface{}) {
 		//self.Expires = val.Expires
 		self.HeartbeatInterval = val.HeartbeatInterval
 		self.HeartbeatTimeout = val.HeartbeatTimeout
-		self.TicketId = &val.TicketId
-		self.Status = *val.Status
+		self.Status = val.Status
 
 	case *HybridOverlayQueryResponseOverlay:
 		val := v.(*HybridOverlayQueryResponseOverlay)
@@ -261,7 +265,7 @@ func (self *OverlayInfo) copy(v interface{}) {
 		self.Type = val.Type
 		self.SubType = val.SubType
 		self.OwnerId = val.OwnerId
-		self.Expires = val.Expires
+		//self.Expires = val.Expires
 		self.Status = val.Status
 
 		if val.Description != nil {
@@ -269,20 +273,15 @@ func (self *OverlayInfo) copy(v interface{}) {
 		}
 		self.Auth = val.Auth
 		self.CrPolicy = val.CrPolicy
-		self.TransPolicy = val.TransPolicy
 	}
 }
 
-type TransPolicy struct {
-	RateControlQuantity int      `json:"rate-control-quantity"`
-	RateControlBitrate  int      `json:"rate-control-bitrate"`
-	TransmissionControl string   `json:"transmission-control"`
-	AuthList            []string `json:"auth-list,omitempty"`
-}
 type PeerInfo struct {
-	PeerId  string   `json:"peer-id"`
-	Address string   `json:"address"`
-	Auth    PeerAuth `json:"auth"`
+	PeerId     string   `json:"peer-id"`
+	InstanceId int64    `json:"instance-id"`
+	Address    string   `json:"address"`
+	Auth       PeerAuth `json:"auth"`
+	TicketId   int      `json:"ticket-id"`
 }
 
 type OverlayAuth struct {
@@ -309,7 +308,6 @@ type HybridOverlayQueryResponseOverlay struct {
 	Description *string       `json:"description,omitempty"`
 	Auth        OverlayAuth   `json:"auth"`
 	CrPolicy    *CrPolicy     `json:"cr-policy,omitempty"`
-	TransPolicy *TransPolicy  `json:"trans_policy,omitempty"`
 }
 
 type HybridOverlayQueryResponse struct {
@@ -321,14 +319,15 @@ type HybridOverlayReportOverlay struct {
 }
 
 type HybridOverlayReportPeer struct {
-	PeerId string     `json:"peer-id"`
-	Status PeerStatus `json:"status"`
-	Auth   PeerAuth   `json:"auth"`
+	PeerId     string   `json:"peer-id"`
+	InstanceId int64    `json:"instance-id"`
+	Auth       PeerAuth `json:"auth"`
 }
 
 type HybridOverlayReport struct {
 	Overlay HybridOverlayReportOverlay `json:"overlay"`
 	Peer    HybridOverlayReportPeer    `json:"peer"`
+	Status  PeerStatus                 `json:"status"`
 }
 
 type HybridOverlayReportResponse struct {
@@ -337,14 +336,15 @@ type HybridOverlayReportResponse struct {
 
 type HybridOverlayRefreshOverlay struct {
 	OverlayId string       `json:"overlay-id"`
-	Expires   *int         `json:"expires,omitempty"`
 	Auth      *OverlayAuth `json:"auth,omitempty"`
 }
 
 type HybridOverlayRefreshPeer struct {
-	PeerId  string   `json:"peer-id"`
-	Address string   `json:"address"`
-	Auth    PeerAuth `json:"auth"`
+	PeerId     string   `json:"peer-id"`
+	InstanceId int64    `json:"instance-id"`
+	Address    string   `json:"address"`
+	Auth       PeerAuth `json:"auth"`
+	Expires    *int     `json:"expires,omitempty"`
 }
 
 type HybridOverlayRefresh struct {
@@ -352,9 +352,15 @@ type HybridOverlayRefresh struct {
 	Peer    HybridOverlayRefreshPeer    `json:"peer"`
 }
 
+type HybridOverlayRefreshResponsePeer struct {
+	PeerId     string `json:"peer-id"`
+	InstanceId int64  `json:"instance-id"`
+	Expires    int    `json:"expires"`
+}
+
 type HybridOverlayRefreshResponse struct {
-	Overlay HybridOverlayRefreshOverlay `json:"overlay"`
-	Peer    HybridOverlayRefreshPeer    `json:"peer"`
+	Overlay HybridOverlayRefreshOverlay      `json:"overlay"`
+	Peer    HybridOverlayRefreshResponsePeer `json:"peer"`
 }
 
 type PeerStatus struct {
@@ -365,11 +371,6 @@ type PeerStatus struct {
 }
 
 type CostMap struct {
-	PeerId  string         `json:"peer_id"`
-	CostMap CostMapCostMap `json:"costmap"`
-}
-
-type CostMapCostMap struct {
 	Primary           []string `json:"primary"`
 	OutgoingCandidate []string `json:"outgoing_candidate"`
 	IncomingCandidate []string `json:"incoming_candidate"`
@@ -385,8 +386,9 @@ type HybridOverlayLeaveOverlay struct {
 }
 
 type HybridOverlayLeavePeer struct {
-	PeerId string    `json:"peer-id"`
-	Auth   *PeerAuth `json:"auth,omitempty"`
+	PeerId     string    `json:"peer-id"`
+	InstanceId int64     `json:"instance-id"`
+	Auth       *PeerAuth `json:"auth,omitempty"`
 }
 
 type HybridOverlayLeave struct {
@@ -422,17 +424,36 @@ type TypeGetter struct {
 }
 
 type PPMessage struct {
-	Ver     byte
-	Type    byte
-	Length  uint16
-	Header  string
-	Content []byte
+	Ver    byte
+	Type   byte
+	Length uint16
+	Header string
+	//ExtensionHeader string
+	Payload []byte
 }
 
-func GetPPMessage(header interface{}, content []byte) *PPMessage {
+func GetPPMessage(header interface{} /*extHeader interface{},*/, payload []byte) *PPMessage {
 	pp := new(PPMessage)
 	pp.Ver = 0x01
 	pp.Type = 0x01
+
+	/*if extHeader != nil {
+		buf, err := json.Marshal(extHeader)
+		if err != nil {
+			logger.Println(logger.ERROR, "extHeader marshal error: ", err)
+			return nil
+		}
+
+		switch header.(type) {
+		case BroadcastDataParams:
+			pp.ExtensionHeader = string(buf)
+			header.(*BroadcastDataParams).ExtHeaderLen = len(pp.ExtensionHeader)
+
+		case GetDataRspParams:
+			pp.ExtensionHeader = string(buf)
+			header.(*GetDataRspParams).ExtHeaderLen = len(pp.ExtensionHeader)
+		}
+	}*/
 
 	buf, err := json.Marshal(header)
 
@@ -442,7 +463,7 @@ func GetPPMessage(header interface{}, content []byte) *PPMessage {
 	}
 	pp.Header = string(buf)
 	pp.Length = uint16(len(pp.Header))
-	pp.Content = content
+	pp.Payload = payload
 
 	return pp
 }
@@ -559,7 +580,7 @@ type PeerBuffermap struct {
 
 type DataPacketPayload struct {
 	Header  *BroadcastData
-	Content *[]byte
+	Payload *[]byte
 }
 
 type DataPacket struct {
@@ -667,8 +688,19 @@ type GetData struct {
 }
 
 type GetDataResponse struct {
-	RspCode   int                 `json:"RspCode"`
-	RspParams BroadcastDataParams `json:"RspParams"`
+	RspCode   int              `json:"RspCode"`
+	RspParams GetDataRspParams `json:"RspParams"`
+}
+
+type GetDataRspParams struct {
+	Peer         GetDataRspParamsPeer       `json:"peer"`
+	Sequence     int                        `json:"sequence"`
+	Payload      BroadcastDataParamsPayload `json:"payload"`
+	ExtHeaderLen int                        `json:"ext-header-len"`
+}
+
+type GetDataRspParamsPeer struct {
+	PeerId string `json:"peer-id"`
 }
 
 type BroadcastData struct {
@@ -677,10 +709,10 @@ type BroadcastData struct {
 }
 
 type BroadcastDataParams struct {
-	Operation *BroadcastDataParamsOperation `json:"operation"`
-	Peer      BroadcastDataParamsPeer       `json:"peer"`
-	App       BroadcastDataParamsApp        `json:"app"`
-	Payload   BroadcastDataParamsPayload    `json:"payload"`
+	Operation    *BroadcastDataParamsOperation `json:"operation"`
+	Peer         BroadcastDataParamsPeer       `json:"peer"`
+	Payload      BroadcastDataParamsPayload    `json:"payload"`
+	ExtHeaderLen int                           `json:"ext-header-len"`
 }
 
 type BroadcastDataParamsOperation struct {
@@ -692,17 +724,17 @@ type BroadcastDataParamsPeer struct {
 	Sequence int    `json:"sequence"`
 }
 
-type BroadcastDataParamsApp struct {
-	AppId string `json:"app-id"`
-}
-
 type BroadcastDataParamsPayload struct {
 	Length      int    `json:"length"`
-	ContentType string `json:"content-type"`
+	PayloadType string `json:"payload-type"`
 }
 
 type BroadcastDataResponse struct {
 	RspCode int `json:"RspCode"`
+}
+
+type BroadcastDataExtensionHeader struct {
+	AppId string `json:"app-id"`
 }
 
 type NetworkPeerInfo struct {

--- a/connect/struct.go
+++ b/connect/struct.go
@@ -85,11 +85,11 @@ type CrPolicy struct {
 }
 
 type HybridOverlayCreationOverlay struct {
-	Title             string      `json:"title"`
-	Type              string      `json:"type"`
-	SubType           string      `json:"sub-type"`
-	OwnerId           string      `json:"owner-id"`
-	Expires           int         `json:"expires"`
+	Title   string `json:"title"`
+	Type    string `json:"type"`
+	SubType string `json:"sub-type"`
+	OwnerId string `json:"owner-id"`
+	//Expires           int         `json:"expires"`
 	Description       string      `json:"description,omitempty"`
 	HeartbeatInterval int         `json:"heartbeat-interval"`
 	HeartbeatTimeout  int         `json:"heartbeat-timeout"`
@@ -106,11 +106,11 @@ type HybridOverlayCreationResponse struct {
 }
 
 type HybridOverlayCreationResponseOverlayInfo struct {
-	OverlayId         string       `json:"overlay-id"`
-	Type              string       `json:"type"`
-	SubType           string       `json:"sub-type"`
-	OwnerId           string       `json:"owner-id"`
-	Expires           int          `json:"expires"`
+	OverlayId string `json:"overlay-id"`
+	Type      string `json:"type"`
+	SubType   string `json:"sub-type"`
+	OwnerId   string `json:"owner-id"`
+	//Expires           int          `json:"expires"`
 	HeartbeatInterval int          `json:"heartbeat-interval"`
 	HeartbeatTimeout  int          `json:"heartbeat-timeout"`
 	Auth              *OverlayAuth `json:"auth,omitempty"`
@@ -142,9 +142,9 @@ type HybridOverlayJoinResponseOverlay struct {
 	OverlayId         string        `json:"overlay-id"`
 	Type              string        `json:"type"`
 	SubType           string        `json:"sub-type"`
+	Status            OverlayStatus `json:"status"`
 	HeartbeatInterval int           `json:"heartbeat-interval"`
 	HeartbeatTimeout  int           `json:"heartbeat-timeout"`
-	Status            OverlayStatus `json:"status"`
 	CrPolicy          *CrPolicy     `json:"cr-policy,omitempty"`
 }
 
@@ -161,10 +161,10 @@ type HybridOverlayJoinResponse struct {
 }
 
 type HybridOverlayModificationOverlay struct {
-	OverlayId   string      `json:"overlay-id"`
-	Title       *string     `json:"title,omitempty"`
-	OwnerId     string      `json:"owner-id"`
-	Expires     *int        `json:"expires,omitempty"`
+	OverlayId string  `json:"overlay-id"`
+	Title     *string `json:"title,omitempty"`
+	OwnerId   string  `json:"owner-id"`
+	//Expires     *int        `json:"expires,omitempty"`
 	Description *string     `json:"description,omitempty"`
 	Auth        OverlayAuth `json:"auth"`
 }
@@ -298,12 +298,12 @@ type OverlayStatus struct {
 }
 
 type HybridOverlayQueryResponseOverlay struct {
-	OverlayId   string        `json:"overlay-id"`
-	Title       string        `json:"title"`
-	Type        string        `json:"type"`
-	SubType     string        `json:"sub-type"`
-	OwnerId     string        `json:"owner-id"`
-	Expires     int           `json:"expires"`
+	OverlayId string `json:"overlay-id"`
+	Title     string `json:"title"`
+	Type      string `json:"type"`
+	SubType   string `json:"sub-type"`
+	OwnerId   string `json:"owner-id"`
+	//Expires     int           `json:"expires"`
 	Status      OverlayStatus `json:"status"`
 	Description *string       `json:"description,omitempty"`
 	Auth        OverlayAuth   `json:"auth"`
@@ -831,12 +831,12 @@ type ApiPeerStatus struct {
 }
 
 type ApiOverlayInfo struct {
-	OverlayId         string      `json:"overlay-id"`
-	Title             string      `json:"title"`
-	Type              string      `json:"type"`
-	SubType           string      `json:"sub-type"`
-	OwnerId           string      `json:"owner-id"`
-	Expires           int         `json:"expires"`
+	OverlayId string `json:"overlay-id"`
+	Title     string `json:"title"`
+	Type      string `json:"type"`
+	SubType   string `json:"sub-type"`
+	OwnerId   string `json:"owner-id"`
+	//Expires           int         `json:"expires"`
 	Description       *string     `json:"description,omitempty"`
 	Auth              OverlayAuth `json:"auth"`
 	TicketId          int         `json:"ticket-id"`

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -1,18 +1,18 @@
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2022 ETRI
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 
 package consts
 
@@ -35,8 +35,8 @@ const (
 )
 
 const (
-	ContentTypeText        string = "text/plain"
-	ContentTypeOctetStream string = "application/octet-stream"
+	PayloadTypeText        string = "text/plain"
+	PayloadTypeOctetStream string = "application/octet-stream"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	//toPeerId := flag.String("connect", "", "Peer ID to connect")
 	title := flag.String("t", "", "Title")
 	desc := flag.String("d", "", "Description")
-	expires := flag.Int("e", 3600, "Overlay Expires")
+	//expires := flag.Int("e", 3600, "Overlay Expires")
 	create := flag.Bool("c", false, "Create Overlay")
 	join := flag.Bool("j", false, "Join Overlay")
 	hbInterval := flag.Int("hi", 10, "Heartbeat interval")
@@ -91,7 +91,7 @@ func main() {
 	logger.Println(logger.INFO, "Instance Id :", instanceId)
 	logger.Println(logger.INFO, "Title :", *title)
 	logger.Println(logger.INFO, "Description :", *desc)
-	logger.Println(logger.INFO, "Expires :", *expires)
+	//logger.Println(logger.INFO, "Expires :", *expires)
 	logger.Println(logger.INFO, "Create :", *create)
 	logger.Println(logger.INFO, "Heartbeat interval :", *hbInterval)
 	logger.Println(logger.INFO, "Heartbeat timeout :", *hbTimeout)
@@ -115,7 +115,7 @@ func main() {
 		overlayCreation.Overlay.Type = "core"
 		overlayCreation.Overlay.SubType = "tree"
 		overlayCreation.Overlay.OwnerId = *peerId
-		overlayCreation.Overlay.Expires = *expires
+		//overlayCreation.Overlay.Expires = *expires
 		overlayCreation.Overlay.Description = *desc
 		if len(overlayCreation.Overlay.Description) <= 0 {
 			overlayCreation.Overlay.Description = "no description"

--- a/peerClient.go
+++ b/peerClient.go
@@ -1,18 +1,18 @@
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2022 ETRI
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 
 package main
 

--- a/webHandler.go
+++ b/webHandler.go
@@ -1,18 +1,18 @@
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2022 ETRI
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 
 package main
 
@@ -66,7 +66,7 @@ func (handler *WebHandler) InitDataHandler(rw http.ResponseWriter, r *http.Reque
 	data := InitData{}
 	data.WEB_SOCKET_PORT = handler.websocketPort
 	data.PEER_ID = (*handler.connectObj).PeerId()
-	data.TICKET_ID = *(*handler.connectObj).OverlayInfo().TicketId
+	data.TICKET_ID = (*handler.connectObj).PeerInfo().TicketId
 	data.OVERLAY_ID = (*handler.connectObj).OverlayInfo().OverlayId
 	data.IS_OWNER = (*handler.connectObj).IsOwner()
 	data.HAS_CONNECTION = (*handler.connectObj).HasConnection()

--- a/webServer.go
+++ b/webServer.go
@@ -1,18 +1,18 @@
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2022 ETRI
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 
 package main
 
@@ -28,12 +28,13 @@ import (
 	"connect"
 	"consts"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"logger"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -121,7 +122,7 @@ func (h *staticHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		localPath = "webClient/index.html"
 	}
 
-	content, err := ioutil.ReadFile(localPath)
+	content, err := os.ReadFile(localPath)
 	if err != nil {
 		w.WriteHeader(404)
 		w.Write([]byte(http.StatusText(404)))
@@ -221,9 +222,9 @@ func (server *HTTPServer) SetApiHandler(handler *ApiHandler) {
 	http.HandleFunc("/api/graphql", handler.HandleApi)
 }
 
-func (server *HTTPServer) Start() {
+func (server *HTTPServer) Start(port int) {
 	go func() {
-		listener, err := net.Listen("tcp", ":0")
+		listener, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 		if err != nil {
 			panic(err)
 		}
@@ -237,6 +238,7 @@ func (server *HTTPServer) Start() {
 		logger.Println(logger.WORK, "HTTP Server start with :", listener.Addr())
 
 		logger.Println(logger.WORK, "")
+
 		panic(http.ServeTLS(listener, nil, "private.crt", "temp.key"))
 
 	}()


### PR DESCRIPTION
- Remove 'trans-policy'
- Add 'instance-id' to 'PEER_INFO'
- Add 'instance-id' to all messages using 'PEER_INFO'
- Move 'ticket-id' and 'expire' in 'OVERLAY_INFO' to 'PEER_INFO'
- Add 'ownership' to HybridOverlayModification request message for change 'owner-id' and 'admin-key'
- Change overlay recovery URL
- Move 'expires' and 'ticket-id' in 'overlay' to 'peer' in HybridOverlayJoin request message 
- Add 'peer' to HybridOverlayJoin response message and move 'expires' and 'ticket-id' in 'overlay' to 'peer'
- Separate 'status' in 'peer' of HybridOverlayReport
- Fix 'costmap' bugs
- Fix exchange IceCandidate issue
- Fix execute path error
- Add change ownership
- Applying 'extension header' to the peer protocol
- Delete 'expires' in 'OVERLAY_INFO'